### PR TITLE
Allow to send beacon with long body

### DIFF
--- a/src/transport/beacon/beacon.ts
+++ b/src/transport/beacon/beacon.ts
@@ -26,16 +26,14 @@ export const request = (
             [FORCE_URLENCODED_KEY]: 1,
         });
 
-        const fullUrl = `${url}?${stringify(query)}${
-            options.rBody ? `&${options.rBody}` : ''
-        }`;
+        const fullUrl = `${url}?${stringify(query)}`;
 
         if (fullUrl.length > URL_CHAR_LIMIT) {
             // Query is to long to realistically be passed further
             return reject(createKnownError('sb.tlq'));
         }
 
-        const response = senderFn(fullUrl);
+        const response = senderFn(fullUrl, options.rBody);
 
         if (!response) {
             return reject();


### PR DESCRIPTION
method sendBeacon uses http method POST for send data
removed data from url and added it to request body because it blocked requests with long data though it available by sendBeacon transport

I hereby agree to the terms of the CLA available at: https://yandex.ru/legal/cla/?lang=ru